### PR TITLE
Fix implicat declaration warning in cgo

### DIFF
--- a/frontend/tcmu/cfunc.go
+++ b/frontend/tcmu/cfunc.go
@@ -19,6 +19,9 @@ void errp(const char *fmt, ...)
 	va_end(va);
 }
 
+extern int shOpen(struct tcmu_device *dev);
+extern void shClose(struct tcmu_device *dev);
+
 int sh_open_cgo(struct tcmu_device *dev) {
 	return shOpen(dev);
 }


### PR DESCRIPTION
Fix following warnings

frontend/tcmu/cfunc.go: In function 'sh_open_cgo':
frontend/tcmu/cfunc.go:23:9: warning: implicit declaration of function 'shOpen' [-Wimplicit-function-declaration]
  return shOpen(dev);
           ^
frontend/tcmu/cfunc.go: In function 'sh_close_cgo':
frontend/tcmu/cfunc.go:27:2: warning: implicit declaration of function 'shClose' [-Wimplicit-function-declaration]
  shClose(dev);
  ^