### PR TITLE
tcmu: Fix poll return 0

### DIFF
--- a/frontend/tcmu/cfunc.go
+++ b/frontend/tcmu/cfunc.go
@@ -72,7 +72,7 @@ int tcmu_wait_for_next_command(struct tcmu_device *dev) {
 
 	poll(&pfd, 1, -1);
 
-	if (pfd.revents != POLLIN) {
+	if (pfd.revents != 0 && pfd.revents != POLLIN) {
 		errp("poll received unexpected revent: 0x%x\n", pfd.revents);
 		return -1;
 	}


### PR DESCRIPTION
This patch will fix `poll received unexpected revent: 0x0`

This event is harmless, and shouldn't result in TCMU polling failure.