### PR TITLE
Replica healthcheck fixes

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -67,7 +67,7 @@ RUN GOPATH=/tmp/docker-longhorn-driver && \
     cd $GOPATH/src/github.com/rancher && \
     git clone https://github.com/cjellick/docker-longhorn-driver.git && \
     cd docker-longhorn-driver && \
-    git checkout 553bfea741326737cc88b9fa99a0b147de2e5830 && \
+    git checkout e861cbf7058bbcdf1c0600469710dc07afeeeeb2 && \
     go build -o /usr/local/bin/docker-longhorn-driver
 
 VOLUME /tmp

--- a/agent/status/common.go
+++ b/agent/status/common.go
@@ -7,7 +7,6 @@ import (
 )
 
 func writeOK(rw http.ResponseWriter) {
-	logrus.Debugf("Reporting OK.")
 	rw.Write([]byte("OK"))
 }
 

--- a/agent/status/replica.go
+++ b/agent/status/replica.go
@@ -7,8 +7,6 @@ import (
 	md "github.com/rancher/go-rancher-metadata/metadata"
 	"github.com/rancher/longhorn/client"
 
-	"strings"
-
 	"github.com/Sirupsen/logrus"
 	"github.com/rancher/longhorn/agent/controller"
 )
@@ -69,14 +67,13 @@ func (s *ReplicaStatus) checkReplicaStatusInController(rw http.ResponseWriter) (
 	}
 	for _, replica := range replicas {
 		if replica.Address == s.address {
-			if strings.EqualFold(replica.Mode, "err") {
+			if replica.Mode == "ERR" {
 				return s.cacheControllerResponse(false, fmt.Sprintf("Replica %v is in error mode.", s.address))
 			}
-			return s.cacheControllerResponse(true, "")
 		}
 	}
 
-	return s.cacheControllerResponse(false, fmt.Sprintf("Replica %v is not in the controller's list of replicas. Current list: %v", s.address, replicas))
+	return s.cacheControllerResponse(true, "")
 }
 
 func (s *ReplicaStatus) reportCacheControllerResponse() (bool, string) {


### PR DESCRIPTION
- In replcia healthcheck: if a replica is not listed in the controller API, consider it healthy.
- Add logic to retry replicas that errored out
- Pull in new docker-longhorn-driver that tweaks the replica
  healthcheck configuration