### PR TITLE
tcmu: Add check_config before add device

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -44,9 +44,9 @@ RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 > /usr/bin/
 
 # Build TCMU
 RUN cd /usr/src && \
-    git clone https://github.com/agrover/tcmu-runner.git && \
+    git clone https://github.com/yasker/tcmu-runner.git && \
     cd tcmu-runner && \
-    git checkout 9b6d458cd3106ee75b1800cb2fbfb6ffe545b669
+    git checkout 8a72eaefada2ad939eff5ac5628c8fdea8f69a19
 RUN cd /usr/src/tcmu-runner && \
     cmake . -Dwith-glfs=false && \
     make && \

--- a/frontend/tcmu/cfunc.go
+++ b/frontend/tcmu/cfunc.go
@@ -19,27 +19,33 @@ void errp(const char *fmt, ...)
 	va_end(va);
 }
 
-extern int shOpen(struct tcmu_device *dev);
-extern void shClose(struct tcmu_device *dev);
+extern bool devCheckConfig(const char *cfgString, char **reason);
+extern int devOpen(struct tcmu_device *dev);
+extern void devClose(struct tcmu_device *dev);
 
-int sh_open_cgo(struct tcmu_device *dev) {
-	return shOpen(dev);
+int dev_open_cgo(struct tcmu_device *dev) {
+	return devOpen(dev);
 }
 
-void sh_close_cgo(struct tcmu_device *dev) {
-	shClose(dev);
+void dev_close_cgo(struct tcmu_device *dev) {
+	devClose(dev);
 }
 
-static struct tcmulib_handler sh_handler = {
+bool dev_check_config_cgo(const char *cfgString, char **reason) {
+	return devCheckConfig(cfgString, reason);
+}
+
+static struct tcmulib_handler lh_handler = {
 	.name = "Longhorn TCMU handler",
 	.subtype = "longhorn",
 	.cfg_desc = "dev_config=longhorn//<id>",
-	.added = sh_open_cgo,
-	.removed = sh_close_cgo,
+	.added = dev_open_cgo,
+	.removed = dev_close_cgo,
+	.check_config = dev_check_config_cgo,
 };
 
 struct tcmulib_context *tcmu_init() {
-	return tcmulib_initialize(&sh_handler, 1, errp);
+	return tcmulib_initialize(&lh_handler, 1, errp);
 }
 
 bool tcmu_poll_master_fd(struct tcmulib_context *cxt) {


### PR DESCRIPTION
A patch for tcmu-runner is needed. So add dependency to `yasker/tcmu-runner`.

Basically tcmu-runner doesn't check if it's the device we want to handle
before open uio device, which caused multiple handlers may contend for the
same uio device(though only one of them should do so).

The patch in tcmu-runner uses check_config to validate the device before
actually open it. Also the handlers in longhorn need to make sure that it only
handle it's own volume, which indicates in dev_config: `longhorn//<volume_name>`