### PR TITLE
RW timeout retry

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -10,11 +10,15 @@ import (
 )
 
 var (
+	//ErrRWTimeout r/w operation timeout
+	ErrRWTimeout = errors.New("r/w timeout")
+
+	opRetries      = 4
 	opReadTimeout  = 15 * time.Second // client read
 	opWriteTimeout = 15 * time.Second // client write
-	ErrRWTimeout   = errors.New("r/w timeout")
 )
 
+//Client replica client
 type Client struct {
 	end       chan struct{}
 	requests  chan *Message
@@ -26,6 +30,7 @@ type Client struct {
 	err       error
 }
 
+//NewClient replica client
 func NewClient(conn net.Conn) *Client {
 	c := &Client{
 		wire:      NewWire(conn),
@@ -41,63 +46,71 @@ func NewClient(conn net.Conn) *Client {
 	return c
 }
 
+//WriteAt replica client
 func (c *Client) WriteAt(buf []byte, offset int64) (int, error) {
 	return c.operation(TypeWrite, buf, offset)
 }
 
+//SetError replica client transport error
 func (c *Client) SetError(err error) {
 	c.responses <- &Message{
 		transportErr: err,
 	}
 }
 
+//ReadAt replica client
 func (c *Client) ReadAt(buf []byte, offset int64) (int, error) {
 	return c.operation(TypeRead, buf, offset)
 }
 
 func (c *Client) operation(op uint32, buf []byte, offset int64) (int, error) {
-	msg := Message{
-		Complete: make(chan struct{}, 1),
-		Type:     op,
-		Offset:   offset,
-		Data:     buf,
-	}
-
-	timeout := func(op uint32) <-chan time.Time {
-		switch op {
-		case TypeRead:
-			return time.After(opReadTimeout)
+	retry := 0
+	for {
+		msg := Message{
+			Complete: make(chan struct{}, 1),
+			Type:     op,
+			Offset:   offset,
+			Data:     buf,
 		}
-		return time.After(opWriteTimeout)
-	}(msg.Type)
 
-	c.requests <- &msg
+		timeout := func(op uint32) <-chan time.Time {
+			switch op {
+			case TypeRead:
+				return time.After(opReadTimeout)
+			}
+			return time.After(opWriteTimeout)
+		}(msg.Type)
 
-	select {
-	case <-msg.Complete:
-	case <-timeout:
-		switch msg.Type {
-		case TypeRead:
-			logrus.Errorln("Read timeout: seq=", msg.Seq, "size=", len(msg.Data)/1024, "(kB)")
-			c.SetError(ErrRWTimeout)
+		c.requests <- &msg
 
-		case TypeWrite:
-			logrus.Errorln("Write timeout: seq=", msg.Seq, "size=", len(msg.Data)/1024, "(kB)")
-			c.SetError(ErrRWTimeout)
+		select {
+		case <-msg.Complete:
+			if msg.Type == TypeError {
+				return 0, errors.New(string(msg.Data))
+			}
+			if msg.Type == TypeEOF {
+				return len(msg.Data), io.EOF
+			}
+			return len(msg.Data), nil
+		case <-timeout:
+			switch msg.Type {
+			case TypeRead:
+				logrus.Errorln("Read timeout on replcia", c.wire.conn.RemoteAddr().String(), "seq=", msg.Seq, "size=", len(msg.Data)/1024, "(kB)")
+			case TypeWrite:
+				logrus.Errorln("Write timeout on replica", c.wire.conn.RemoteAddr().String(), "seq=", msg.Seq, "size=", len(msg.Data)/1024, "(kB)")
+			}
+			if retry < opRetries {
+				retry++
+				logrus.Errorln("Retry ", retry, "on replica", c.wire.conn.RemoteAddr().String(), "seq=", msg.Seq, "size=", len(msg.Data)/1024, "(kB)")
+			} else {
+				c.SetError(ErrRWTimeout)
+				return 0, ErrRWTimeout
+			}
 		}
 	}
-
-	if msg.Type == TypeError {
-		return 0, errors.New(string(msg.Data))
-	}
-
-	if msg.Type == TypeEOF {
-		return len(msg.Data), io.EOF
-	}
-
-	return len(msg.Data), nil
 }
 
+//Close replica client
 func (c *Client) Close() {
 	c.wire.Close()
 	c.end <- struct{}{}

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -10,10 +10,9 @@ import (
 )
 
 var (
-	opReadTimeout   = 15 * time.Second // client read
-	opWriteTimeout  = 15 * time.Second // client write
-	errReadTimeout  = errors.New("read timeout")
-	errWriteTimeout = errors.New("write timeout")
+	opReadTimeout  = 15 * time.Second // client read
+	opWriteTimeout = 15 * time.Second // client write
+	ErrRWTimeout   = errors.New("r/w timeout")
 )
 
 type Client struct {
@@ -79,14 +78,13 @@ func (c *Client) operation(op uint32, buf []byte, offset int64) (int, error) {
 	case <-timeout:
 		switch msg.Type {
 		case TypeRead:
-			c.SetError(errReadTimeout)
 			logrus.Errorln("Read timeout: seq=", msg.Seq, "size=", len(msg.Data)/1024, "(kB)")
+			c.SetError(ErrRWTimeout)
 
 		case TypeWrite:
-			c.SetError(errWriteTimeout)
 			logrus.Errorln("Write timeout: seq=", msg.Seq, "size=", len(msg.Data)/1024, "(kB)")
+			c.SetError(ErrRWTimeout)
 		}
-		// stats.Print()//flush automaticalyupon timeout
 	}
 
 	if msg.Type == TypeError {


### PR DESCRIPTION
Notes:
- writes are retried
- but direct block write I/O is supposed to be atomic on a block level. So concurrent 'same write' ops idempotence should still hold...