### PR TITLE
package: launch script for simple version longhorn

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -4,5 +4,5 @@ RUN apt-get update && apt-get install -y kmod curl nfs-common
 RUN curl -sSL -o share-mnt https://github.com/rancher/runc/releases/download/share-mnt-v0.0.3/share-mnt && \
     chmod u+x share-mnt && mv share-mnt /usr/bin
 
-COPY longhorn longhorn-agent launch launch-driver docker-longhorn-driver copy-binary launch-with-vm-backing-file /usr/bin/
+COPY longhorn longhorn-agent launch launch-driver docker-longhorn-driver copy-binary launch-with-vm-backing-file launch-simple-longhorn /usr/bin/
 CMD ["longhorn"]

--- a/package/launch-simple-longhorn
+++ b/package/launch-simple-longhorn
@@ -1,0 +1,17 @@
+set -x
+modprobe configfs
+modprobe target_core_user
+mount -t configfs none /sys/kernel/config
+mount --rbind /host/dev /dev
+
+if [ -z $1 ]
+then
+	echo Need a volume name as first parameter
+	exit -1
+fi
+
+volume=$1
+
+longhorn replica --size 1g --listen localhost:9502 /volume/ &
+sleep 1
+exec longhorn --debug controller --frontend tcmu --replica tcp://localhost:9502 $volume


### PR DESCRIPTION
It will start an single replica longhorn system, running with TCMU frontend
inside container. The volume size is 1Gb.

It can be run with:

`docker run -it --privileged -v /dev:/host/dev -v /volume/ rancher/longhorn bash -c "launch-simple-longhorn volume_name"`