### PR TITLE
Update share-mnt to v0.1.2

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 RUN apt-get update && apt-get install -y kmod curl nfs-common
 
-RUN curl -sSL -o share-mnt https://github.com/rancher/runc/releases/download/share-mnt-v0.0.3/share-mnt && \
+RUN curl -sSL -o share-mnt https://github.com/rancher/runc/releases/download/share-mnt-v0.1.2/share-mnt && \
     chmod u+x share-mnt && mv share-mnt /usr/bin
 
 COPY longhorn longhorn-agent launch launch-driver docker-longhorn-driver copy-binary launch-with-vm-backing-file launch-simple-longhorn /usr/bin/


### PR DESCRIPTION
Addresses #201

Had to update share-mnt to work with docker 1.11. The previous version only worked with docker 1.10 and down. The new version is also backwards compatible.