### PR TITLE
Revert back to use `rest` frontend as default test frontend

### DIFF
--- a/integration/data/common.py
+++ b/integration/data/common.py
@@ -59,7 +59,7 @@ def dev(request):
         REPLICA2
     ])
     assert v.replicaCount == 2
-    d = get_fusedev()
+    d = get_restdev()
 
     return d
 
@@ -83,7 +83,7 @@ def backing_dev(request):
         BACKED_REPLICA2
     ])
     assert v.replicaCount == 2
-    d = get_fusedev()
+    d = get_restdev()
 
     return d
 

--- a/integration/data/frontend.py
+++ b/integration/data/frontend.py
@@ -17,13 +17,24 @@ class restdev:
         self.dev = dev
 
     def readat(self, offset, length):
-        data = self.dev.readat(offset=offset, length=length)["data"]
+        try:
+            data = self.dev.readat(offset=offset, length=length)["data"]
+        except cattle.ApiError as e:
+            if 'EOF' in str(e):
+                return []
+            raise e
         return base64.decodestring(data)
 
     def writeat(self, offset, data):
         l = len(data)
         encoded_data = base64.encodestring(data)
-        return self.dev.writeat(offset=offset, length=l, data=encoded_data)
+        try:
+            ret = self.dev.writeat(offset=offset, length=l, data=encoded_data)
+        except cattle.ApiError as e:
+            if 'EOF' in str(e):
+                raise IOError('No space left on the disk')
+            raise e
+        return ret
 
 
 class fusedev:

--- a/package/launch-simple-longhorn
+++ b/package/launch-simple-longhorn
@@ -11,4 +11,4 @@ volume=$1
 
 longhorn replica --size 1g --listen localhost:9502 /volume/ &
 sleep 1
-exec longhorn --debug controller --frontend fuse --replica tcp://localhost:9502 $volume
+exec longhorn --debug controller --frontend tcmu --replica tcp://localhost:9502 $volume

--- a/scripts/integration-test
+++ b/scripts/integration-test
@@ -41,7 +41,7 @@ then
 	mount --rbind /host/dev /dev
 fi
 
-./bin/longhorn controller --frontend fuse --enable-backend file test-volume &
+./bin/longhorn controller --frontend rest --enable-backend file test-volume &
 controller_pid=$!
 ./bin/longhorn replica $temp &
 replica1_pid=$!


### PR DESCRIPTION
`fuse` frontend still have issue with direct_io(#207), thus cause time failure from time to time. Switch back to `rest` for now.