### PR TITLE
Improved sync mechanism for rebuild during snapshotting

### DIFF
--- a/controller/client/controller_client.go
+++ b/controller/client/controller_client.go
@@ -152,6 +152,16 @@ func (c *ControllerClient) CheckReplica(address string) error {
 	return c.post(replica.Actions["check"], &replica, nil)
 }
 
+func (c *ControllerClient) PrepareRebuild(address string) (*rest.PrepareRebuildOutput, error) {
+	var output rest.PrepareRebuildOutput
+	replica, err := c.GetReplica(address)
+	if err != nil {
+		return nil, err
+	}
+	err = c.post(replica.Actions["preparerebuild"], &replica, &output)
+	return &output, err
+}
+
 func (c *ControllerClient) GetVolume() (*rest.Volume, error) {
 	var volumes rest.VolumeCollection
 

--- a/controller/client/controller_client.go
+++ b/controller/client/controller_client.go
@@ -138,6 +138,20 @@ func (c *ControllerClient) UpdateReplica(replica rest.Replica) (rest.Replica, er
 	return resp, err
 }
 
+func (c *ControllerClient) GetReplica(address string) (*rest.Replica, error) {
+	resp := &rest.Replica{}
+	err := c.get("/replicas/"+address, &resp)
+	return resp, err
+}
+
+func (c *ControllerClient) CheckReplica(address string) error {
+	replica, err := c.GetReplica(address)
+	if err != nil {
+		return err
+	}
+	return c.post(replica.Actions["check"], &replica, nil)
+}
+
 func (c *ControllerClient) GetVolume() (*rest.Volume, error) {
 	var volumes rest.VolumeCollection
 

--- a/controller/control.go
+++ b/controller/control.go
@@ -237,6 +237,26 @@ func (c *Controller) CheckReplica(address string) error {
 	return nil
 }
 
+func (c *Controller) PrepareRebuildReplica(address string) ([]string, error) {
+	c.Lock()
+	defer c.Unlock()
+
+	replica, rwReplica, err := c.getCurrentAndRWReplica(address)
+	if err != nil {
+		return nil, err
+	}
+	if replica.Mode != types.WO {
+		return nil, fmt.Errorf("Invalid mode %v for replica %v to prepare rebuild", replica.Mode, address)
+	}
+
+	rwChain, err := getReplicaChain(rwReplica.Address)
+	if err != nil {
+		return nil, err
+	}
+
+	return rwChain[1:], nil
+}
+
 func (c *Controller) SetReplicaMode(address string, mode types.Mode) error {
 	switch mode {
 	case types.ERR:

--- a/controller/rest/model.go
+++ b/controller/rest/model.go
@@ -31,6 +31,11 @@ type ReplicaCollection struct {
 	Data []Replica `json:"data"`
 }
 
+type DiskCollection struct {
+	client.Collection
+	Data []string `json:"data"`
+}
+
 type StartInput struct {
 	client.Resource
 	Replicas []string `json:"replicas"`
@@ -53,6 +58,11 @@ type RevertInput struct {
 type JournalInput struct {
 	client.Resource
 	Limit int `json:"limit"`
+}
+
+type PrepareRebuildOutput struct {
+	client.Resource
+	Disks []string `json:"disks"`
 }
 
 func NewVolume(context *api.ApiContext, name string, replicas int) *Volume {
@@ -87,6 +97,7 @@ func NewReplica(context *api.ApiContext, address string, mode types.Mode) *Repli
 		Mode:    string(mode),
 	}
 	r.Actions["check"] = context.UrlBuilder.ActionLink(r.Resource, "check")
+	r.Actions["preparerebuild"] = context.UrlBuilder.ActionLink(r.Resource, "preparerebuild")
 	return r
 }
 
@@ -113,10 +124,16 @@ func NewSchema() *client.Schemas {
 	schemas.AddType("snapshotInput", SnapshotInput{})
 	schemas.AddType("revertInput", RevertInput{})
 	schemas.AddType("journalInput", JournalInput{})
+	schemas.AddType("prepareRebuildOutput", PrepareRebuildOutput{})
 
 	replica := schemas.AddType("replica", Replica{})
 	replica.CollectionMethods = []string{"GET", "POST"}
 	replica.ResourceMethods = []string{"GET", "PUT"}
+	replica.ResourceActions = map[string]client.Action{
+		"preparerebuild": {
+			Output: "prepareRebuildOutput",
+		},
+	}
 
 	f := replica.ResourceFields["address"]
 	f.Create = true

--- a/controller/rest/model.go
+++ b/controller/rest/model.go
@@ -77,14 +77,17 @@ func NewVolume(context *api.ApiContext, name string, replicas int) *Volume {
 }
 
 func NewReplica(context *api.ApiContext, address string, mode types.Mode) *Replica {
-	return &Replica{
+	r := &Replica{
 		Resource: client.Resource{
-			Id:   EncodeID(address),
-			Type: "replica",
+			Id:      EncodeID(address),
+			Type:    "replica",
+			Actions: map[string]string{},
 		},
 		Address: address,
 		Mode:    string(mode),
 	}
+	r.Actions["check"] = context.UrlBuilder.ActionLink(r.Resource, "check")
+	return r
 }
 
 func DencodeID(id string) (string, error) {

--- a/controller/rest/model.go
+++ b/controller/rest/model.go
@@ -76,7 +76,7 @@ func NewVolume(context *api.ApiContext, name string, replicas int) *Volume {
 	return v
 }
 
-func NewReplica(address string, mode types.Mode) *Replica {
+func NewReplica(context *api.ApiContext, address string, mode types.Mode) *Replica {
 	return &Replica{
 		Resource: client.Resource{
 			Id:   EncodeID(address),
@@ -125,18 +125,18 @@ func NewSchema() *client.Schemas {
 
 	volumes := schemas.AddType("volume", Volume{})
 	volumes.ResourceActions = map[string]client.Action{
-		"revert": client.Action{
+		"revert": {
 			Input:  "revertInput",
 			Output: "volume",
 		},
-		"start": client.Action{
+		"start": {
 			Input:  "startInput",
 			Output: "volume",
 		},
-		"shutdown": client.Action{
+		"shutdown": {
 			Output: "volume",
 		},
-		"snapshot": client.Action{
+		"snapshot": {
 			Input:  "snapshotInput",
 			Output: "snapshotOutput",
 		},

--- a/controller/rest/replica.go
+++ b/controller/rest/replica.go
@@ -91,3 +91,18 @@ func (s *Server) UpdateReplica(rw http.ResponseWriter, req *http.Request) error 
 
 	return s.GetReplica(rw, req)
 }
+
+func (s *Server) CheckReplica(rw http.ResponseWriter, req *http.Request) error {
+	vars := mux.Vars(req)
+	id, err := DencodeID(vars["id"])
+	if err != nil {
+		rw.WriteHeader(http.StatusNotFound)
+		return nil
+	}
+
+	if err := s.c.CheckReplica(id); err != nil {
+		return err
+	}
+
+	return s.GetReplica(rw, req)
+}

--- a/controller/rest/replica.go
+++ b/controller/rest/replica.go
@@ -13,7 +13,7 @@ func (s *Server) ListReplicas(rw http.ResponseWriter, req *http.Request) error {
 	apiContext := api.GetApiContext(req)
 	resp := client.GenericCollection{}
 	for _, r := range s.c.ListReplicas() {
-		resp.Data = append(resp.Data, NewReplica(r.Address, r.Mode))
+		resp.Data = append(resp.Data, NewReplica(apiContext, r.Address, r.Mode))
 	}
 
 	resp.ResourceType = "replica"
@@ -34,7 +34,7 @@ func (s *Server) GetReplica(rw http.ResponseWriter, req *http.Request) error {
 		return nil
 	}
 
-	apiContext.Write(s.getReplica(id))
+	apiContext.Write(s.getReplica(apiContext, id))
 	return nil
 }
 
@@ -49,14 +49,14 @@ func (s *Server) CreateReplica(rw http.ResponseWriter, req *http.Request) error 
 		return err
 	}
 
-	apiContext.Write(s.getReplica(replica.Address))
+	apiContext.Write(s.getReplica(apiContext, replica.Address))
 	return nil
 }
 
-func (s *Server) getReplica(id string) *Replica {
+func (s *Server) getReplica(context *api.ApiContext, id string) *Replica {
 	for _, r := range s.c.ListReplicas() {
 		if r.Address == id {
-			return NewReplica(r.Address, r.Mode)
+			return NewReplica(context, r.Address, r.Mode)
 		}
 	}
 	return nil
@@ -89,6 +89,5 @@ func (s *Server) UpdateReplica(rw http.ResponseWriter, req *http.Request) error 
 		return err
 	}
 
-	apiContext.Write(s.getReplica(id))
-	return nil
+	return s.GetReplica(rw, req)
 }

--- a/controller/rest/replica.go
+++ b/controller/rest/replica.go
@@ -106,3 +106,29 @@ func (s *Server) CheckReplica(rw http.ResponseWriter, req *http.Request) error {
 
 	return s.GetReplica(rw, req)
 }
+
+func (s *Server) PrepareRebuildReplica(rw http.ResponseWriter, req *http.Request) error {
+	vars := mux.Vars(req)
+	id, err := DencodeID(vars["id"])
+	if err != nil {
+		rw.WriteHeader(http.StatusNotFound)
+		return nil
+	}
+
+	disks, err := s.c.PrepareRebuildReplica(id)
+	if err != nil {
+		return err
+	}
+
+	apiContext := api.GetApiContext(req)
+	resp := &PrepareRebuildOutput{
+		Resource: client.Resource{
+			Id:   id,
+			Type: "prepareRebuildOutput",
+		},
+		Disks: disks,
+	}
+
+	apiContext.Write(&resp)
+	return nil
+}

--- a/controller/rest/router.go
+++ b/controller/rest/router.go
@@ -30,6 +30,7 @@ func NewRouter(s *Server) *mux.Router {
 	router.Methods("GET").Path("/v1/replicas/{id}").Handler(f(schemas, s.GetReplica))
 	router.Methods("POST").Path("/v1/replicas").Handler(f(schemas, s.CreateReplica))
 	router.Methods("POST").Path("/v1/replicas/{id}").Queries("action", "check").Handler(f(schemas, s.CheckReplica))
+	router.Methods("POST").Path("/v1/replicas/{id}").Queries("action", "preparerebuild").Handler(f(schemas, s.PrepareRebuildReplica))
 	router.Methods("DELETE").Path("/v1/replicas/{id}").Handler(f(schemas, s.DeleteReplica))
 	router.Methods("PUT").Path("/v1/replicas/{id}").Handler(f(schemas, s.UpdateReplica))
 

--- a/controller/rest/router.go
+++ b/controller/rest/router.go
@@ -29,6 +29,7 @@ func NewRouter(s *Server) *mux.Router {
 	router.Methods("GET").Path("/v1/replicas").Handler(f(schemas, s.ListReplicas))
 	router.Methods("GET").Path("/v1/replicas/{id}").Handler(f(schemas, s.GetReplica))
 	router.Methods("POST").Path("/v1/replicas").Handler(f(schemas, s.CreateReplica))
+	router.Methods("POST").Path("/v1/replicas/{id}").Queries("action", "check").Handler(f(schemas, s.CheckReplica))
 	router.Methods("DELETE").Path("/v1/replicas/{id}").Handler(f(schemas, s.DeleteReplica))
 	router.Methods("PUT").Path("/v1/replicas/{id}").Handler(f(schemas, s.UpdateReplica))
 

--- a/package/launch
+++ b/package/launch
@@ -1,25 +1,29 @@
 #!/bin/bash
 
-if [ "$1" == "controller" ]; then
-        mount --rbind /host/dev /dev
+is_controller=0
+fe=0
+frontend=
+for i in "$@"
+do
+        if [ $fe -eq 1 ]
+        then
+                frontend=$i
+                break
+        fi
+        case $i in
+                controller)
+                        is_controller=1
+                        ;;
+                --frontend)
+                        fe=1
+                        ;;
+                *)
+                        ;;
+        esac
+done
 
-        frontend=
-        fe=0
-        for i in "$@"
-        do
-                if [ $fe -eq 1 ]
-                then
-                        frontend=$i
-                        break
-                fi
-                case $i in
-                        --frontend)
-                                fe=1
-                                ;;
-                        *)
-                                ;;
-                esac
-        done
+if [ $is_controller -eq 1 ]; then
+        mount --rbind /host/dev /dev
 
         if [ "$frontend" == "tcmu" ]
         then


### PR DESCRIPTION
Now we allow snapshot happens during the rebuild, so there are several critical points we need to sync snapshot operation with rebuild operation.

1. The volume head disk metadata file will be used for future snapshots, so it needs to be updated ASAP.
2. The final check of new replica needs to be done without racing against snapshot operation in the process.

This patchset fixes #266 