### PR TITLE
Allow volume with underscore in name

### DIFF
--- a/app/controller.go
+++ b/app/controller.go
@@ -57,6 +57,10 @@ func startController(c *cli.Context) error {
 	}
 	name := c.Args()[0]
 
+	if !util.ValidVolumeName(name) {
+		return errors.New("invalid target name")
+	}
+
 	listen := c.String("listen")
 	backends := c.StringSlice("enable-backend")
 	replicas := c.StringSlice("replica")
@@ -88,8 +92,8 @@ func startController(c *cli.Context) error {
 	router := http.Handler(rest.NewRouter(server))
 
 	router = util.FilteredLoggingHandler(map[string]struct{}{
-		"/v1/volumes":  struct{}{},
-		"/v1/replicas": struct{}{},
+		"/v1/volumes":  {},
+		"/v1/replicas": {},
 	}, os.Stdout, router)
 	router = handlers.ProxyHeaders(router)
 

--- a/frontend/tgt/scsi.go
+++ b/frontend/tgt/scsi.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/rancher/longhorn/util"
 	"github.com/yasker/go-iscsi-helper/iscsi"
 	iutil "github.com/yasker/go-iscsi-helper/util"
 	"github.com/yasker/nsfilelock"
@@ -43,7 +44,7 @@ func NewScsiDevice(name, backingFile, bsType, bsOpts string) (*ScsiDevice, error
 }
 
 func GetTargetName(name string) string {
-	return "iqn.2014-09.com.rancher:" + name
+	return "iqn.2014-09.com.rancher:" + util.Volume2ISCSIName(name)
 }
 
 func GetLocalIP() (string, error) {

--- a/integration/core/test_cli.py
+++ b/integration/core/test_cli.py
@@ -14,7 +14,7 @@ REPLICA2 = 'tcp://localhost:9505'
 
 BACKUP_DEST = '/tmp/longhorn-backup'
 
-VOLUME_NAME = 'test-volume'
+VOLUME_NAME = 'test-volume_1.0'
 VOLUME_SIZE = str(4 * 1024 * 1024)  # 4M
 
 
@@ -461,7 +461,8 @@ def test_backup_core(bin, controller_client, replica_client,
     assert backup2_info["SnapshotName"] == snapshot2
 
     cmd = [bin, 'backup', 'inspect',
-           "vfs:///tmp/longhorn-backup?backup=backup-1234&volume=test-volume"]
+           "vfs:///tmp/longhorn-backup?backup=backup-1234"
+           + "&volume=test-volume_1.0"]
     with pytest.raises(subprocess.CalledProcessError) as e:
         subprocess.check_call(cmd)
         assert 'cannot find' in str(e.value)
@@ -480,7 +481,8 @@ def test_backup_core(bin, controller_client, replica_client,
     assert os.path.exists(BACKUP_DEST)
 
     cmd = [bin, 'backup', 'inspect',
-           "vfs:///tmp/longhorn-backup?backup=backup-1234&volume=test-volume"]
+           "vfs:///tmp/longhorn-backup?backup=backup-1234"
+           + "&volume=test-volume_1.0"]
     with pytest.raises(subprocess.CalledProcessError) as e:
         subprocess.check_call(cmd)
         assert 'cannot find' in str(e.value)

--- a/integration/data/common.py
+++ b/integration/data/common.py
@@ -31,7 +31,7 @@ BACKUP_DEST = 'vfs://' + BACKUP_DIR
 
 BACKING_FILE = 'backing_file.raw'
 
-VOLUME_NAME = 'test-volume'
+VOLUME_NAME = 'test-volume_1.0'
 
 
 def _file(f):

--- a/integration/data/test_backup.py
+++ b/integration/data/test_backup.py
@@ -7,7 +7,7 @@ import common
 from common import dev, backing_dev  # NOQA
 from common import read_dev, read_from_backing_file, BACKUP_DEST
 
-VOLUME_NAME = 'test-volume'
+VOLUME_NAME = 'test-volume_1.0'
 VOLUME_SIZE = str(4 * 1024 * 1024)  # 4M
 
 

--- a/scripts/integration-test
+++ b/scripts/integration-test
@@ -41,7 +41,7 @@ then
 	mount --rbind /host/dev /dev
 fi
 
-./bin/longhorn controller --frontend tgt --enable-backend file test-volume &
+./bin/longhorn controller --frontend tgt --enable-backend file test-volume_1.0 &
 controller_pid=$!
 ./bin/longhorn replica $temp &
 replica1_pid=$!

--- a/util/util.go
+++ b/util/util.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -16,7 +17,8 @@ import (
 )
 
 var (
-	parsePattern = regexp.MustCompile(`(.*):(\d+)`)
+	MaximumVolumeNameSize = 64
+	parsePattern          = regexp.MustCompile(`(.*):(\d+)`)
 )
 
 func ParseAddresses(name string) (string, string, string, error) {
@@ -129,4 +131,16 @@ func remove(path string) error {
 	case <-time.After(30 * time.Second):
 		return fmt.Errorf("timeout trying to delete %s", path)
 	}
+}
+
+func ValidVolumeName(name string) bool {
+	if len(name) > MaximumVolumeNameSize {
+		return false
+	}
+	validName := regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]+$`)
+	return validName.MatchString(name)
+}
+
+func Volume2ISCSIName(name string) string {
+	return strings.Replace(name, "_", ":", -1)
 }


### PR DESCRIPTION
We need to additional handling in tgt frontend in order to swap `_` with `:`,
because `_` isn't allowed in the iSCSI name.

Also update test cases to include all valid name.

As well as add check for volume name and limit the length of volume name to 64
bytes.