### PR TITLE
New snapshot removal mechanism

### DIFF
--- a/app/snapshot.go
+++ b/app/snapshot.go
@@ -22,6 +22,7 @@ func SnapshotCmd() cli.Command {
 			SnapshotRevertCmd(),
 			SnapshotLsCmd(),
 			SnapshotRmCmd(),
+			SnapshotPurgeCmd(),
 			SnapshotInfoCmd(),
 		},
 		Action: func(c *cli.Context) {
@@ -60,6 +61,17 @@ func SnapshotRmCmd() cli.Command {
 		Action: func(c *cli.Context) {
 			if err := rmSnapshot(c); err != nil {
 				logrus.Fatalf("Error running rm snapshot command: %v", err)
+			}
+		},
+	}
+}
+
+func SnapshotPurgeCmd() cli.Command {
+	return cli.Command{
+		Name: "purge",
+		Action: func(c *cli.Context) {
+			if err := purgeSnapshot(c); err != nil {
+				logrus.Fatalf("Error running purge snapshot command: %v", err)
 			}
 		},
 	}
@@ -132,6 +144,17 @@ func rmSnapshot(c *cli.Context) error {
 	}
 
 	return lastErr
+}
+
+func purgeSnapshot(c *cli.Context) error {
+	url := c.GlobalString("url")
+	task := sync.NewTask(url)
+
+	if err := task.PurgeSnapshots(); err != nil {
+		return fmt.Errorf("Failed to purge snapshots: %v", err)
+	}
+
+	return nil
 }
 
 func lsSnapshot(c *cli.Context) error {

--- a/app/snapshot.go
+++ b/app/snapshot.go
@@ -129,9 +129,7 @@ func rmSnapshot(c *cli.Context) error {
 	task := sync.NewTask(url)
 
 	for _, name := range c.Args() {
-		if err := task.DeleteSnapshot(name); err == nil {
-			fmt.Printf("deleted %s\n", name)
-		} else {
+		if err := task.DeleteSnapshot(name); err != nil {
 			lastErr = err
 			fmt.Fprintf(os.Stderr, "Failed to delete %s: %v\n", name, err)
 		}

--- a/integration/core/test_replica.py
+++ b/integration/core/test_replica.py
@@ -163,13 +163,22 @@ def test_remove_disk(client):
                        'volume-snap-000.img']
 
     with pytest.raises(cattle.ApiError) as e:
+        r.markdiskasremoved(name='003')
+        assert "Can not find snapshot" in e
+
+    with pytest.raises(cattle.ApiError) as e:
         r.prepareremovedisk(name='003')
         assert "Can not find snapshot" in e
+
+    with pytest.raises(cattle.ApiError) as e:
+        r.markdiskasremoved(name='volume-head-002.img')
+        assert "Can not mark the active" in e
 
     with pytest.raises(cattle.ApiError) as e:
         r.prepareremovedisk(name='volume-head-002.img')
         assert "Can not delete the active" in e
 
+    r.markdiskasremoved(name='001')
     ops = r.prepareremovedisk(name='001')["operations"]
     assert len(ops) == 0
 
@@ -195,6 +204,7 @@ def test_remove_last_disk(client):
     assert r.chain == ['volume-head-002.img', 'volume-snap-001.img',
                        'volume-snap-000.img']
 
+    r.markdiskasremoved(name='volume-snap-000.img')
     ops = r.prepareremovedisk(name='volume-snap-000.img')["operations"]
     assert len(ops) == 2
     assert ops[0].action == "coalesce"

--- a/integration/data/cmd.py
+++ b/integration/data/cmd.py
@@ -39,7 +39,13 @@ def snapshot_ls():
 
 def snapshot_info():
     cmd = [_bin(), '--debug', 'snapshot', 'info']
-    return subprocess.check_output(cmd)
+    output = subprocess.check_output(cmd)
+    return json.loads(output)
+
+
+def snapshot_purge():
+    cmd = [_bin(), '--debug', 'snapshot', 'purge']
+    return subprocess.check_call(cmd)
 
 
 def backup_create(snapshot, dest):

--- a/integration/data/common.py
+++ b/integration/data/common.py
@@ -33,6 +33,7 @@ BACKUP_DEST = 'vfs://' + BACKUP_DIR
 BACKING_FILE = 'backing_file.raw'
 
 VOLUME_NAME = 'test-volume_1.0'
+VOLUME_HEAD = 'volume-head'
 
 thread_failed = False
 

--- a/integration/data/snapshot_tree.py
+++ b/integration/data/snapshot_tree.py
@@ -1,0 +1,201 @@
+import cmd
+import common
+from common import read_dev, VOLUME_HEAD
+
+
+def snapshot_tree_build(dev, offset, length, strict=True):
+    # snap["0a"] -> snap["0b"] -> snap["0c"]
+    #                 |-> snap["1a"] -> snap["1b"] -> snap["1c"]
+    #                 \-> snap["2a"] -> snap["2b"] -> snap["2c"]
+    #                       \-> snap["3a"] -> snap["3b"] -> snap["3c"] -> head
+
+    snap = {}
+    snap_data = {}
+
+    snap_data["0a"] = common.random_string(length)
+    common.verify_data(dev, offset, snap_data["0a"])
+    snap["0a"] = cmd.snapshot_create()
+
+    snap_data["0b"] = common.random_string(length)
+    common.verify_data(dev, offset, snap_data["0b"])
+    snap["0b"] = cmd.snapshot_create()
+
+    snap_data["0c"] = common.random_string(length)
+    common.verify_data(dev, offset, snap_data["0c"])
+    snap["0c"] = cmd.snapshot_create()
+
+    cmd.snapshot_revert(snap["0b"])
+
+    snap_data["1a"] = common.random_string(length)
+    common.verify_data(dev, offset, snap_data["1a"])
+    snap["1a"] = cmd.snapshot_create()
+
+    snap_data["1b"] = common.random_string(length)
+    common.verify_data(dev, offset, snap_data["1b"])
+    snap["1b"] = cmd.snapshot_create()
+
+    snap_data["1c"] = common.random_string(length)
+    common.verify_data(dev, offset, snap_data["1c"])
+    snap["1c"] = cmd.snapshot_create()
+
+    cmd.snapshot_revert(snap["0b"])
+
+    snap_data["2a"] = common.random_string(length)
+    common.verify_data(dev, offset, snap_data["2a"])
+    snap["2a"] = cmd.snapshot_create()
+
+    snap_data["2b"] = common.random_string(length)
+    common.verify_data(dev, offset, snap_data["2b"])
+    snap["2b"] = cmd.snapshot_create()
+
+    snap_data["2c"] = common.random_string(length)
+    common.verify_data(dev, offset, snap_data["2c"])
+    snap["2c"] = cmd.snapshot_create()
+
+    cmd.snapshot_revert(snap["2a"])
+
+    snap_data["3a"] = common.random_string(length)
+    common.verify_data(dev, offset, snap_data["3a"])
+    snap["3a"] = cmd.snapshot_create()
+
+    snap_data["3b"] = common.random_string(length)
+    common.verify_data(dev, offset, snap_data["3b"])
+    snap["3b"] = cmd.snapshot_create()
+
+    snap_data["3c"] = common.random_string(length)
+    common.verify_data(dev, offset, snap_data["3c"])
+    snap["3c"] = cmd.snapshot_create()
+
+    snapshot_tree_verify(dev, offset, length, snap, snap_data, strict)
+    return snap, snap_data
+
+
+# snapshot_tree_verify_relationship won't check head or initial snapshot if
+# "strict" is False
+def snapshot_tree_verify_relationship(snap, strict):
+    info = cmd.snapshot_info()
+
+    assert snap["0a"] in info
+    assert info[snap["0a"]]["children"] == [snap["0b"]]
+
+    assert snap["0b"] in info
+    assert info[snap["0b"]]["parent"] == snap["0a"]
+    assert len(info[snap["0b"]]["children"]) == 3
+    assert snap["0c"] in info[snap["0b"]]["children"]
+    assert snap["1a"] in info[snap["0b"]]["children"]
+    assert snap["2a"] in info[snap["0b"]]["children"]
+
+    assert snap["0c"] in info
+    assert info[snap["0c"]]["parent"] == snap["0b"]
+    assert info[snap["0c"]]["children"] == []
+
+    assert snap["1a"] in info
+    assert info[snap["1a"]]["parent"] == snap["0b"]
+    assert info[snap["1a"]]["children"] == [snap["1b"]]
+
+    assert snap["1b"] in info
+    assert info[snap["1b"]]["parent"] == snap["1a"]
+    assert info[snap["1b"]]["children"] == [snap["1c"]]
+
+    assert snap["1c"] in info
+    assert info[snap["1c"]]["parent"] == snap["1b"]
+    assert info[snap["1c"]]["children"] == []
+
+    assert snap["2a"] in info
+    assert info[snap["2a"]]["parent"] == snap["0b"]
+    assert len(info[snap["2a"]]["children"]) == 2
+    assert snap["2b"] in info[snap["2a"]]["children"]
+    assert snap["3a"] in info[snap["2a"]]["children"]
+
+    assert snap["2b"] in info
+    assert info[snap["2b"]]["parent"] == snap["2a"]
+    assert info[snap["2b"]]["children"] == [snap["2c"]]
+
+    assert snap["2c"] in info
+    assert info[snap["2c"]]["parent"] == snap["2b"]
+    assert info[snap["2c"]]["children"] == []
+
+    assert snap["3a"] in info
+    assert info[snap["3a"]]["parent"] == snap["2a"]
+    assert info[snap["3a"]]["children"] == [snap["3b"]]
+
+    assert snap["3b"] in info
+    assert info[snap["3b"]]["parent"] == snap["3a"]
+    assert info[snap["3b"]]["children"] == [snap["3c"]]
+
+    assert snap["3c"] in info
+    assert info[snap["3c"]]["parent"] == snap["3b"]
+
+    if strict:
+        assert len(info) == 13
+        assert info[snap["0a"]]["parent"] == ""
+        assert info[snap["3c"]]["children"] == [VOLUME_HEAD]
+        assert VOLUME_HEAD in info
+        assert info[VOLUME_HEAD]["parent"] == snap["3c"]
+        assert info[VOLUME_HEAD]["children"] == []
+
+        output = cmd.snapshot_ls()
+        assert output == '''ID
+{}
+{}
+{}
+{}
+{}
+{}
+'''.format(snap["3c"], snap["3b"], snap["3a"],
+           snap["2a"], snap["0b"], snap["0a"])
+
+
+def snapshot_tree_verify_data(dev, offset, length, snap, snap_data):
+    cmd.snapshot_revert(snap["0a"])
+    readed = read_dev(dev, offset, length)
+    assert readed == snap_data["0a"]
+
+    cmd.snapshot_revert(snap["0b"])
+    readed = read_dev(dev, offset, length)
+    assert readed == snap_data["0b"]
+
+    cmd.snapshot_revert(snap["0c"])
+    readed = read_dev(dev, offset, length)
+    assert readed == snap_data["0c"]
+
+    cmd.snapshot_revert(snap["1a"])
+    readed = read_dev(dev, offset, length)
+    assert readed == snap_data["1a"]
+
+    cmd.snapshot_revert(snap["1b"])
+    readed = read_dev(dev, offset, length)
+    assert readed == snap_data["1b"]
+
+    cmd.snapshot_revert(snap["1c"])
+    readed = read_dev(dev, offset, length)
+    assert readed == snap_data["1c"]
+
+    cmd.snapshot_revert(snap["2a"])
+    readed = read_dev(dev, offset, length)
+    assert readed == snap_data["2a"]
+
+    cmd.snapshot_revert(snap["2b"])
+    readed = read_dev(dev, offset, length)
+    assert readed == snap_data["2b"]
+
+    cmd.snapshot_revert(snap["2c"])
+    readed = read_dev(dev, offset, length)
+    assert readed == snap_data["2c"]
+
+    cmd.snapshot_revert(snap["3a"])
+    readed = read_dev(dev, offset, length)
+    assert readed == snap_data["3a"]
+
+    cmd.snapshot_revert(snap["3b"])
+    readed = read_dev(dev, offset, length)
+    assert readed == snap_data["3b"]
+
+    cmd.snapshot_revert(snap["3c"])
+    readed = read_dev(dev, offset, length)
+    assert readed == snap_data["3c"]
+
+
+def snapshot_tree_verify(dev, offset, length, snap, snap_data, strict=False):
+    snapshot_tree_verify_relationship(snap, strict)
+    snapshot_tree_verify_data(dev, offset, length, snap, snap_data)

--- a/replica/client/client.go
+++ b/replica/client/client.go
@@ -145,6 +145,17 @@ func (c *ReplicaClient) PrepareRemoveDisk(disk string) (rest.PrepareRemoveDiskOu
 	return output, err
 }
 
+func (c *ReplicaClient) MarkDiskAsRemoved(disk string) error {
+	r, err := c.GetReplica()
+	if err != nil {
+		return err
+	}
+
+	return c.post(r.Actions["markdiskasremoved"], &rest.MarkDiskAsRemovedInput{
+		Name: disk,
+	}, nil)
+}
+
 func (c *ReplicaClient) OpenReplica() error {
 	r, err := c.GetReplica()
 	if err != nil {

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -396,9 +396,8 @@ func (r *Replica) PrepareRemoveDisk(name string) ([]PrepareRemoveAction, error) 
 		return nil, fmt.Errorf("Can not delete the active differencing disk")
 	}
 
-	logrus.Infof("Mark disk %v as removed", disk)
-	if err := r.markDiskAsRemoved(disk); err != nil {
-		return nil, fmt.Errorf("Fail to mark disk %v as removed: %v", disk, err)
+	if !data.Removed {
+		return nil, fmt.Errorf("Disk %v hasn't been marked as removed", disk)
 	}
 
 	targetDisks := []string{}

--- a/replica/replica_test.go
+++ b/replica/replica_test.go
@@ -575,13 +575,7 @@ func (s *TestSuite) TestPrepareRemove(c *C) {
 
 	actions, err = r.PrepareRemoveDisk("002")
 	c.Assert(err, IsNil)
-	c.Assert(actions, HasLen, 2)
-	c.Assert(actions[0].Action, Equals, OpCoalesce)
-	c.Assert(actions[0].Source, Equals, "volume-snap-001.img")
-	c.Assert(actions[0].Target, Equals, "volume-snap-002.img")
-	c.Assert(actions[1].Action, Equals, OpReplace)
-	c.Assert(actions[1].Source, Equals, "volume-snap-001.img")
-	c.Assert(actions[1].Target, Equals, "volume-snap-002.img")
+	c.Assert(actions, HasLen, 0)
 
 	err = r.Snapshot("003", true, now)
 	c.Assert(err, IsNil)
@@ -605,21 +599,25 @@ func (s *TestSuite) TestPrepareRemove(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(r.activeDiskData[4].Removed, Equals, true)
 
-	actions, err = r.PrepareRemoveDisk("003")
+	actions, err = r.PrepareRemoveDisk("002")
 	c.Assert(err, IsNil)
-	c.Assert(actions, HasLen, 4)
+	c.Assert(actions, HasLen, 2)
 	c.Assert(actions[0].Action, Equals, OpCoalesce)
 	c.Assert(actions[0].Source, Equals, "volume-snap-002.img")
 	c.Assert(actions[0].Target, Equals, "volume-snap-003.img")
 	c.Assert(actions[1].Action, Equals, OpReplace)
 	c.Assert(actions[1].Source, Equals, "volume-snap-002.img")
 	c.Assert(actions[1].Target, Equals, "volume-snap-003.img")
-	c.Assert(actions[2].Action, Equals, OpCoalesce)
-	c.Assert(actions[2].Source, Equals, "volume-snap-003.img")
-	c.Assert(actions[2].Target, Equals, "volume-snap-004.img")
-	c.Assert(actions[3].Action, Equals, OpReplace)
-	c.Assert(actions[3].Source, Equals, "volume-snap-003.img")
-	c.Assert(actions[3].Target, Equals, "volume-snap-004.img")
+
+	actions, err = r.PrepareRemoveDisk("003")
+	c.Assert(err, IsNil)
+	c.Assert(actions, HasLen, 2)
+	c.Assert(actions[0].Action, Equals, OpCoalesce)
+	c.Assert(actions[0].Source, Equals, "volume-snap-003.img")
+	c.Assert(actions[0].Target, Equals, "volume-snap-004.img")
+	c.Assert(actions[1].Action, Equals, OpReplace)
+	c.Assert(actions[1].Source, Equals, "volume-snap-003.img")
+	c.Assert(actions[1].Target, Equals, "volume-snap-004.img")
 }
 
 func byteEquals(c *C, expected, obtained []byte) {

--- a/replica/replica_test.go
+++ b/replica/replica_test.go
@@ -533,10 +533,17 @@ func (s *TestSuite) TestPrepareRemove(c *C) {
 		volume-head-002.img
 	*/
 
+	err = r.MarkDiskAsRemoved("001")
+	c.Assert(err, IsNil)
+	c.Assert(r.activeDiskData[2].Removed, Equals, true)
+
 	actions, err := r.PrepareRemoveDisk("001")
 	c.Assert(err, IsNil)
 	c.Assert(actions, HasLen, 0)
-	c.Assert(r.activeDiskData[2].Removed, Equals, true)
+
+	err = r.MarkDiskAsRemoved("volume-snap-000.img")
+	c.Assert(err, IsNil)
+	c.Assert(r.activeDiskData[1].Removed, Equals, true)
 
 	actions, err = r.PrepareRemoveDisk("volume-snap-000.img")
 	c.Assert(err, IsNil)
@@ -547,7 +554,6 @@ func (s *TestSuite) TestPrepareRemove(c *C) {
 	c.Assert(actions[1].Action, Equals, OpReplace)
 	c.Assert(actions[1].Source, Equals, "volume-snap-000.img")
 	c.Assert(actions[1].Target, Equals, "volume-snap-001.img")
-	c.Assert(r.activeDiskData[1].Removed, Equals, true)
 
 	err = r.Snapshot("002", true, now)
 	c.Assert(err, IsNil)
@@ -563,6 +569,10 @@ func (s *TestSuite) TestPrepareRemove(c *C) {
 	c.Assert(len(r.volume.files), Equals, 5)
 
 	/* https://github.com/rancher/longhorn/issues/184 */
+	err = r.MarkDiskAsRemoved("002")
+	c.Assert(err, IsNil)
+	c.Assert(r.activeDiskData[3].Removed, Equals, true)
+
 	actions, err = r.PrepareRemoveDisk("002")
 	c.Assert(err, IsNil)
 	c.Assert(actions, HasLen, 2)
@@ -591,6 +601,10 @@ func (s *TestSuite) TestPrepareRemove(c *C) {
 	c.Assert(len(r.activeDiskData), Equals, 7)
 	c.Assert(len(r.volume.files), Equals, 7)
 
+	err = r.MarkDiskAsRemoved("003")
+	c.Assert(err, IsNil)
+	c.Assert(r.activeDiskData[4].Removed, Equals, true)
+
 	actions, err = r.PrepareRemoveDisk("003")
 	c.Assert(err, IsNil)
 	c.Assert(actions, HasLen, 4)
@@ -606,7 +620,6 @@ func (s *TestSuite) TestPrepareRemove(c *C) {
 	c.Assert(actions[3].Action, Equals, OpReplace)
 	c.Assert(actions[3].Source, Equals, "volume-snap-003.img")
 	c.Assert(actions[3].Target, Equals, "volume-snap-004.img")
-	c.Assert(r.activeDiskData[4].Removed, Equals, true)
 }
 
 func byteEquals(c *C, expected, obtained []byte) {

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -57,6 +57,11 @@ type ReplaceDiskInput struct {
 	Source string `json:"source"`
 }
 
+type MarkDiskAsRemovedInput struct {
+	client.Resource
+	Name string `json:"name"`
+}
+
 type PrepareRemoveDiskInput struct {
 	client.Resource
 	Name string `json:"name"`
@@ -96,6 +101,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		actions["removedisk"] = true
 		actions["replacedisk"] = true
 		actions["revert"] = true
+		actions["markdiskasremoved"] = true
 		actions["prepareremovedisk"] = true
 		actions["setrevisioncounter"] = true
 	case replica.Closed:
@@ -103,6 +109,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		actions["removedisk"] = true
 		actions["replacedisk"] = true
 		actions["revert"] = true
+		actions["markdiskasremoved"] = true
 		actions["prepareremovedisk"] = true
 	case replica.Dirty:
 		actions["setrebuilding"] = true
@@ -112,6 +119,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		actions["removedisk"] = true
 		actions["replacedisk"] = true
 		actions["revert"] = true
+		actions["markdiskasremoved"] = true
 		actions["prepareremovedisk"] = true
 	case replica.Rebuilding:
 		actions["snapshot"] = true
@@ -153,6 +161,7 @@ func NewSchema() *client.Schemas {
 	schemas.AddType("rebuildingInput", RebuildingInput{})
 	schemas.AddType("snapshotInput", SnapshotInput{})
 	schemas.AddType("removediskInput", RemoveDiskInput{})
+	schemas.AddType("markDiskAsRemovedInput", MarkDiskAsRemovedInput{})
 	schemas.AddType("revertInput", RevertInput{})
 	schemas.AddType("prepareRemoveDiskInput", PrepareRemoveDiskInput{})
 	schemas.AddType("prepareRemoveDiskOutput", PrepareRemoveDiskOutput{})
@@ -199,7 +208,11 @@ func NewSchema() *client.Schemas {
 			Input: "revisionCounter",
 		},
 		"replacedisk": {
-			Input:  "replacediskinput",
+			Input:  "replacediskInput",
+			Output: "replica",
+		},
+		"markdiskasremoved": {
+			Input:  "markDiskAsRemovedInput",
 			Output: "replica",
 		},
 	}

--- a/replica/rest/replica.go
+++ b/replica/rest/replica.go
@@ -99,6 +99,16 @@ func (s *Server) ReplaceDisk(rw http.ResponseWriter, req *http.Request) error {
 	return s.doOp(req, s.s.ReplaceDisk(input.Target, input.Source))
 }
 
+func (s *Server) MarkDiskAsRemoved(rw http.ResponseWriter, req *http.Request) error {
+	var input MarkDiskAsRemovedInput
+	apiContext := api.GetApiContext(req)
+	if err := apiContext.Read(&input); err != nil {
+		return err
+	}
+
+	return s.doOp(req, s.s.MarkDiskAsRemoved(input.Name))
+}
+
 func (s *Server) PrepareRemoveDisk(rw http.ResponseWriter, req *http.Request) error {
 	var input PrepareRemoveDiskInput
 	apiContext := api.GetApiContext(req)

--- a/replica/rest/router.go
+++ b/replica/rest/router.go
@@ -54,13 +54,14 @@ func NewRouter(s *Server) *mux.Router {
 		"snapshot":           s.SnapshotReplica,
 		"open":               s.OpenReplica,
 		"close":              s.CloseReplica,
-		"removedisk":         s.RemoveDisk,
-		"replacedisk":        s.ReplaceDisk,
 		"setrebuilding":      s.SetRebuilding,
 		"create":             s.Create,
 		"revert":             s.RevertReplica,
-		"prepareremovedisk":  s.PrepareRemoveDisk,
 		"setrevisioncounter": s.SetRevisionCounter,
+		"markdiskasremoved":  s.MarkDiskAsRemoved,
+		"prepareremovedisk":  s.PrepareRemoveDisk,
+		"removedisk":         s.RemoveDisk,
+		"replacedisk":        s.ReplaceDisk,
 	}
 
 	for name, action := range actions {

--- a/replica/server.go
+++ b/replica/server.go
@@ -205,6 +205,18 @@ func (s *Server) ReplaceDisk(target, source string) error {
 	return s.r.ReplaceDisk(target, source)
 }
 
+func (s *Server) MarkDiskAsRemoved(name string) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.r == nil {
+		return nil
+	}
+
+	logrus.Infof("Marking disk %v as removed", name)
+	return s.r.MarkDiskAsRemoved(name)
+}
+
 func (s *Server) PrepareRemoveDisk(name string) ([]PrepareRemoveAction, error) {
 	s.Lock()
 	defer s.Unlock()

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -41,20 +41,8 @@ func (t *Task) DeleteSnapshot(snapshot string) error {
 		}
 	}
 
-	ops := make(map[string][]replica.PrepareRemoveAction)
 	for _, replica := range replicas {
 		if err = t.markSnapshotAsRemoved(&replica, snapshot); err != nil {
-			return err
-		}
-
-		ops[replica.Address], err = t.prepareRemoveSnapshot(&replica, snapshot)
-		if err != nil {
-			return err
-		}
-	}
-
-	for _, replica := range replicas {
-		if err := t.processRemoveSnapshot(&replica, snapshot, ops[replica.Address]); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Now remove snapshot will be two steps:
1. When user call `snapshot rm <snapshot_name>`, system will only mark snapshot as `Removed` and won't show it in the chain. But the real file is still intact.
2. When user call `snapshot purge`, system will scan the snapshot tree and
a. Mark any system generated snapshots(e.g. created when rebuilding happens) as `Removed`
b. Remove any `Removed` snapshot from hard drive if possible.

We still unable to remove snapshot in following scenarios:
1. It has multiple children snapshots.
2. It's the parent of volume head disk(live disk).

In the scenario we cannot remove the requested snapshot, we will keep them on the hard drive and retry next time when `snapshot purge` called again.

The reason we've separate the steps are because removing a snapshot can be IO intense operation, especially the coalescing part.