### PR TITLE
Update deploy example.yaml

### DIFF
--- a/deploy/example-backupstore.yaml
+++ b/deploy/example-backupstore.yaml
@@ -1,39 +1,35 @@
-apiVersion: extensions/v1beta1
-kind: Deployment
+apiVersion: v1
+kind: Pod
 metadata:
-  name: longhorn-test-backupstore
+  name: longhorn-test-nfs
   labels:
-    app: longhorn-nfs
+    app: longhorn-test-nfs
 spec:
-  replicas: 1
-  template:
-    metadata:
-      labels:
-        app: longhorn-nfs
-    spec:
-      containers:
-        - name: longhorn-test-backupstore-pod
-          image: docker.io/erezhorev/dockerized_nfs_server
-          securityContext:
-            privileged: true
-          ports:
-          # dummy port to keep k8s happy
-          - containerPort: 1111
-            name: longhorn-nfs
-          args: ["/opt/backupstore"]
+  containers:
+  - name: longhorn-test-nfs-container
+    image: janeczku/nfs-ganesha:latest
+    imagePullPolicy: Always
+    env:
+    - name: EXPORT_ID
+      value: "14"
+    - name: EXPORT_PATH
+      value: /opt/backupstore
+    - name: PSEUDO_PATH
+      value: /opt/backupstore
+    command: ["bash", "-c", "mkdir -p /opt/backupstore && /opt/start_nfs.sh"]
+    securityContext:
+      capabilities:
+        add: ["SYS_ADMIN", "DAC_READ_SEARCH"]
 ---
 kind: Service
 apiVersion: v1
 metadata:
-  labels:
-    app: longhorn-nfs
-  name: longhorn-nfs-svc
+  name: longhorn-test-nfs-svc
 spec:
   selector:
-    app: longhorn-nfs
+    app: longhorn-test-nfs
   clusterIP: None
   ports:
-  # dummy port to keep k8s happy
-  - name: longhorn-nfs
-    port: 1111
-    targetPort: longhorn-nfs
+  - name: notnecessary
+    port: 1234
+    targetPort: 1234

--- a/deploy/example.yaml
+++ b/deploy/example.yaml
@@ -1,15 +1,13 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
+apiVersion: v1
+kind: Namespace
 metadata:
-  name: longhorn-bind
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: longhorn-role
-subjects:
-- kind: ServiceAccount
+  name: longhorn-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
   name: longhorn-service-account
-  namespace: default
+  namespace: longhorn-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -24,6 +22,9 @@ rules:
   - "*"
 - apiGroups: [""]
   resources: ["pods"]
+  verbs: ["*"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
   verbs: ["*"]
 - apiGroups: ["longhorn.rancher.io"]
   resources: ["nodes"]
@@ -41,10 +42,18 @@ rules:
   resources: ["controllers"]
   verbs: ["*"]
 ---
-apiVersion: v1
-kind: ServiceAccount
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
 metadata:
+  name: longhorn-bind
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: longhorn-role
+subjects:
+- kind: ServiceAccount
   name: longhorn-service-account
+  namespace: longhorn-system
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
@@ -52,6 +61,7 @@ metadata:
   labels:
     app: longhorn-manager
   name: longhorn-manager
+  namespace: longhorn-system
 spec:
   template:
     metadata:
@@ -67,8 +77,7 @@ spec:
           mountPath: /data/
       containers:
       - name: longhorn-manager
-        image: rancher/longhorn-manager:6c51e02
-        imagePullPolicy: Always
+        image: rancher/longhorn-manager:4d21cac
         securityContext:
           privileged: true
         command: ["launch-manager", "-d",
@@ -124,6 +133,7 @@ metadata:
   labels:
     app: longhorn-manager
   name: longhorn-backend
+  namespace: longhorn-system
 spec:
   selector:
     app: longhorn-manager
@@ -139,6 +149,7 @@ metadata:
   labels:
     app: longhorn-ui
   name: longhorn-ui
+  namespace: longhorn-system
 spec:
   replicas: 1
   template:
@@ -148,8 +159,7 @@ spec:
     spec:
       containers:
       - name: longhorn-ui
-        image: rancher/longhorn-ui:b161e3a
-        imagePullPolicy: IfNotPresent
+        image: rancher/longhorn-ui:99622cb
         ports:
         - containerPort: 8000
           name: longhorn-ui
@@ -163,6 +173,7 @@ metadata:
   labels:
     app: longhorn-ui
   name: longhorn-frontend
+  namespace: longhorn-system
 spec:
   selector:
     app: longhorn-ui
@@ -177,6 +188,7 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: longhorn-driver
+  namespace: longhorn-system
 spec:
   template:
     metadata:
@@ -184,8 +196,17 @@ spec:
       labels:
         app: longhorn-driver
     spec:
+      initContainers:
+      - name: init-container
+        image: rancher/longhorn-driver:4d21cac
+        securityContext:
+            privileged: true
+        command: ["/checkdependency.sh"]
+        volumeMounts:
+        - name: host-proc-mount
+          mountPath: /host/proc/
       containers:
-        - image: rancher/longhorn-driver:5260c7b
+        - image: rancher/longhorn-driver:4d21cac
           imagePullPolicy: Always
           name: longhorn-driver-container
           command: ["/entrypoint.sh"]
@@ -194,6 +215,8 @@ spec:
           volumeMounts:
             - mountPath: /flexmnt
               name: flexvolume-longhorn-mount
+            - mountPath: /binmnt
+              name: usr-local-bin-mount
           env:
             - name: LONGHORN_BACKEND_SVC
               value: "longhorn-backend"
@@ -204,5 +227,12 @@ spec:
       volumes:
         - name: flexvolume-longhorn-mount
           hostPath:
-            path: /home/kubernetes/flexvolume
-            #path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/
+            path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/
+            #FOR GKE
+            #path: /home/kubernetes/flexvolume/
+        - name: usr-local-bin-mount
+          hostPath:
+            path: /usr/local/bin/
+        - name: host-proc-mount
+          hostPath:
+            path: /proc/


### PR DESCRIPTION
Major updates:
1. Longhorn will now run in the `longhorn-system` namespace by default.
2. Improvement on Longhorn Driver includes dependency check when started and
automatic static-linked jq installation
3. Use ganesha as the NFS server for testing to remove the dependency of
`nfs-kernel-server` on the host.