### PR TITLE
AWS S3 backup store settings added to READ.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,14 +256,14 @@ A backup target represents a backupstore in the Longhorn. The backup target can 
 #### Setup AWS S3 backupstore
 1. Create a new bucket in AWS S3.
 
-2. By following that [guide](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html#id_users_create_console) create a new AWS IAM user, with the following permissions set:
+2. Follow the [guide](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html#id_users_create_console) to create a new AWS IAM user, with the following permissions set:
 
 ```
 {
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "VisualEditor0",
+            "Sid": "GrantLonghornBackupstoreAccess0",
             "Effect": "Allow",
             "Action": [
                 "s3:PutObject",
@@ -272,8 +272,8 @@ A backup target represents a backupstore in the Longhorn. The backup target can 
                 "s3:DeleteObject"
             ],
             "Resource": [
-                "arn:aws:s3:::your-bucket-name",
-                "arn:aws:s3:::your-bucket-name/*"
+                "arn:aws:s3:::<your-bucket-name>",
+                "arn:aws:s3:::<your-bucket-name>/*"
             ]
         }
     ]
@@ -281,26 +281,26 @@ A backup target represents a backupstore in the Longhorn. The backup target can 
 ```
 
 
-3. Add a new secret with a name such as `aws` in the namespace where longhorn is placed(`longhorn-system` by default). Put to that secret the following keys:
+3. Create a Kubernetes secret with a name such as `aws-secret` in the namespace where longhorn is placed(`longhorn-system` by default). Put the following keys in the secret:
 
 ```
-AWS_ACCESS_KEY_ID: YOUR_AWS_ACCESS_KEY_ID
-AWS_SECRET_ACCESS_KEY: YOUR_AWS_SECRET_ACCESS_KEY
+AWS_ACCESS_KEY_ID: <your_aws_access_key_id>
+AWS_SECRET_ACCESS_KEY: <your_aws_secret_access_key>
 ```
 
 4. Go to the Longhorn UI and set `Settings/General/BackupTarget` to
 ```
-s3://your-bucket-name@your-aws-region/
+s3://<your-bucket-name>@<your-aws-region>/
 ```
 Pay attention that you should have `/` at the end, otherwise you will get an error.
 
 5.  Set `Settings/General/BackupTargetSecret` to
 ```
-aws
+aws-secret
 ```
 Your secret name with AWS keys from 3rd point.
 
-#### Setup a testing backupstore
+#### Setup a local testing backupstore
 We provides two testing purpose backupstore based on NFS server and Minio S3 server for testing, in `./deploy/backupstores`.
 
 Use following command to setup a Minio S3 server for BackupStore after `longhorn-system` was created.

--- a/README.md
+++ b/README.md
@@ -253,7 +253,52 @@ A backupstore is a NFS server or S3 compatible server.
 
 A backup target represents a backupstore in the Longhorn. The backup target can be set at `Settings/General/BackupTarget`
 
-If user is using a S3 compatible server as the backup target, a backup target secret is needed for authentication informations. User need to manually create it as a Kubernetes Secret in the `longhorn-system` namespace. See below for details.
+#### Setup AWS S3 backupstore
+1. Create a new bucket in AWS S3.
+
+2. By following that [guide](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html#id_users_create_console) create a new AWS IAM user, with the following permissions set:
+
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject",
+                "s3:GetObject",
+                "s3:ListBucket",
+                "s3:DeleteObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::your-bucket-name",
+                "arn:aws:s3:::your-bucket-name/*"
+            ]
+        }
+    ]
+}
+```
+
+
+3. Add a new secret with a name such as `aws` in the namespace where longhorn is placed(`longhorn-system` by default). Put to that secret the following keys:
+
+```
+AWS_ACCESS_KEY_ID: YOUR_AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY: YOUR_AWS_SECRET_ACCESS_KEY
+```
+
+4. Go to the Longhorn UI and set `Settings/General/BackupTarget` to
+```
+s3://your-bucket-name@your-aws-region/
+```
+Pay attention that you should have `/` at the end, otherwise you will get an error.
+
+5.  Set `Settings/General/BackupTargetSecret` to
+```
+aws
+```
+Your secret name with AWS keys from 3rd point.
 
 #### Setup a testing backupstore
 We provides two testing purpose backupstore based on NFS server and Minio S3 server for testing, in `./deploy/backupstores`.


### PR DESCRIPTION
Based on the issue #279, new documentation added with the examples of AWS S3 backup store configuration.