### PR TITLE
Longhorn v0.3.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can read more details of Longhorn and its design [here](http://rancher.com/m
 
 Longhorn is a work in progress. It's an alpha quality software at the moment. We appreciate your comments as we continue to work on it.
 
-The latest release of Longhorn is **v0.3.2**, shipped with Longhorn Engine **v0.3.0** as the default engine image.
+The latest release of Longhorn is **v0.3.3**, shipped with Longhorn Engine **v0.3.3** as the default engine image.
 
 ## Source code
 Longhorn is 100% open source software. Project source code is spread across a number of repos:


### PR DESCRIPTION
Engine image: rancher/longhorn-engine:v0.3.3
Manager image: rancher/longhorn-manager:v0.3.3
UI Image: rancher/longhorn-ui:v0.3.3

New features:

1. #299 Support set the default number of replicas (replica count) and dynamic adjust replica count of an attached volume.
2. Live upgrade for Engine image became beta. Upgrade from Engine v0.3.0 to v0.3.3 can be done without volume downtime (except if you need the fix for #324 2TB volume size limitation)

Notice Longhorn Engine has been updated to v0.3.3. Please follow the steps [here](https://github.com/rancher/longhorn/blob/master/docs/upgrade.md#upgrade-engine-images) to upgrade engines.

See [here](https://github.com/rancher/longhorn/milestone/6?closed=1) for the list of bugs fixed.