### PR TITLE
specify default namespace explicitly

### DIFF
--- a/deploy/backupstores/minio-backupstore.yaml
+++ b/deploy/backupstores/minio-backupstore.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: minio-secret
+  namespace: default
 type: Opaque
 data:
   AWS_ACCESS_KEY_ID: bG9uZ2hvcm4tdGVzdC1hY2Nlc3Mta2V5 # longhorn-test-access-key
@@ -24,6 +25,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: longhorn-test-minio
+  namespace: default
   labels:
     app: longhorn-test-minio
 spec:
@@ -55,6 +57,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: minio-service
+  namespace: default
 spec:
   selector:
     app: longhorn-test-minio


### PR DESCRIPTION
I was following the docs about setting up a [mini based local backupstore](https://github.com/rancher/longhorn/blob/master/docs/snapshot-backup.md#setup-a-local-testing-backupstore)

But got the following error on the ui:
```
error listing backups: error listing backup volumes: Failed to execute: 
/var/lib/rancher/longhorn/engine-binaries/rancher-longhorn-engine-v0.5.0/longhorn [backup ls --volume-only s3://backupbucket@us-east-1/backupstore],
output AWS Error: RequestError send request failed Get http://minio-service.default:9000/backupbucket?delimiter=%!F(MISSING)&prefix=backupstore%!F(MISSING): dial tcp: lookup minio-service.default on 10.27.240.10:53: no such host , stderr, time="2019-06-04T07:34:32Z" level=error msg="{\n\n}" pkg=s3 time="2019-06-04T07:34:32Z" 
level=error msg="Fail to list s3: AWS Error: RequestError send request failed Get http://minio-service.default:9000/backupbucket?delimiter=%!F(MISSING)&prefix=backupstore%!F(MISSING): dial tcp: lookup minio-service.default on 10.27.240.10:53: no such host\n" pkg=s3 time="2019-06-04T07:34:32Z" 
level=error msg="AWS Error: RequestError send request failed Get http://minio-service.default:9000/backupbucket?delimiter=%!F(MISSING)&prefix=backupstore%!F(MISSING): dial tcp: lookup minio-service.default on 10.27.240.10:53: no such host\n" , error exit status 1
```

I figured that the `longhorn-system` namespace was active when the `kubectl apply -f <URL>` was running.

The minio secret is referencing to the service url as [minio-service.default](https://github.com/rancher/longhorn/blob/master/deploy/backupstores/minio-backupstore.yaml#L9)
If the namspace is explicit for the pod/svc the kubectl apply will work independently of the actual namsepace.